### PR TITLE
[design] 등록 수정 페이지 반응형 css 추가 및 서브타이틀 바 컴포넌트 호버 추가

### DIFF
--- a/client/src/components/Modify/style.ts
+++ b/client/src/components/Modify/style.ts
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 
-export const Container = styled.div`
+export const Container = styled.main`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  /* max-width: 1200px; */
   width: 100%;
   margin-top: 40px;
   /* border: 4px solid red; */
@@ -15,18 +16,26 @@ export const TitleWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
-  max-width: 1264px;
+  width: 90%;
+  /* max-width: 1200px; */
   border-bottom: 4px solid black;
 `;
 
 export const InputTitle = styled.input`
   width: 100%;
-  margin-left: 476px;
+  text-align: center;
   border: none;
   outline: none;
   font-size: 2.25rem;
   color: var(--gray200);
+  @media (max-width: 767px) {
+    font-size: 1rem;
+  }
+  @media (min-width: 768px) and (max-width: 1023px) {
+    font-size: 1.5rem;
+  }
+  @media (min-width: 1024px) {
+  }
 `;
 
 export const ContentsWrapper = styled.div`
@@ -34,7 +43,7 @@ export const ContentsWrapper = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   margin-top: 16px;
-  width: 100%;
+  width: 90%;
   height: 100%;
   margin-top: 24px;
   /* border: 4px solid red; */
@@ -53,6 +62,12 @@ export const InputContents = styled.input`
   border: none;
   outline: none;
   color: var(--gray200);
+  @media (max-width: 767px) {
+    font-size: 0.5rem;
+  }
+  @media (min-width: 768px) and (max-width: 1023px) {
+    font-size: 0.75rem;
+  }
 `;
 
 export const BtnWrapper = styled.div`
@@ -68,10 +83,23 @@ export const RegisterBtn = styled.button`
   height: 48px;
   border-radius: 20px;
   font-weight: var(--font-weight-700);
-  margin-top: 16px;
+  margin-bottom: 16px;
   font-size: var(--font-size-24);
   border: 0;
   color: white;
   font-family: "Roboto";
   background-color: var(--color-darkblue);
+
+  @media (max-width: 767px) {
+    font-size: 0.75rem;
+    max-width: 100px;
+    height: 32px;
+  }
+  @media (min-width: 768px) and (max-width: 1023px) {
+    max-width: 120px;
+    font-size: 1rem;
+    height: 36px;
+  }
+  @media (min-width: 1024px) {
+  }
 `;

--- a/client/src/components/Register/style.ts
+++ b/client/src/components/Register/style.ts
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 
-export const Container = styled.div`
+export const Container = styled.main`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  /* max-width: 1200px; */
   width: 100%;
   margin-top: 40px;
   /* border: 4px solid red; */
@@ -15,18 +16,26 @@ export const TitleWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
-  max-width: 1264px;
+  width: 90%;
+  /* max-width: 1200px; */
   border-bottom: 4px solid black;
 `;
 
 export const InputTitle = styled.input`
   width: 100%;
-  margin-left: 476px;
+  text-align: center;
   border: none;
   outline: none;
   font-size: 2.25rem;
   color: var(--gray200);
+  @media (max-width: 767px) {
+    font-size: 1rem;
+  }
+  @media (min-width: 768px) and (max-width: 1023px) {
+    font-size: 1.5rem;
+  }
+  @media (min-width: 1024px) {
+  }
 `;
 
 export const ContentsWrapper = styled.div`
@@ -34,7 +43,7 @@ export const ContentsWrapper = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   margin-top: 16px;
-  width: 100%;
+  width: 90%;
   height: 100%;
   margin-top: 24px;
   /* border: 4px solid red; */
@@ -53,6 +62,12 @@ export const InputContents = styled.input`
   border: none;
   outline: none;
   color: var(--gray200);
+  @media (max-width: 767px) {
+    font-size: 0.5rem;
+  }
+  @media (min-width: 768px) and (max-width: 1023px) {
+    font-size: 0.75rem;
+  }
 `;
 
 export const BtnWrapper = styled.div`
@@ -68,10 +83,23 @@ export const RegisterBtn = styled.button`
   height: 48px;
   border-radius: 20px;
   font-weight: var(--font-weight-700);
-  margin-top: 16px;
+  margin-bottom: 16px;
   font-size: var(--font-size-24);
   border: 0;
   color: white;
   font-family: "Roboto";
   background-color: var(--color-darkblue);
+
+  @media (max-width: 767px) {
+    font-size: 0.75rem;
+    max-width: 100px;
+    height: 32px;
+  }
+  @media (min-width: 768px) and (max-width: 1023px) {
+    max-width: 120px;
+    font-size: 1rem;
+    height: 36px;
+  }
+  @media (min-width: 1024px) {
+  }
 `;

--- a/client/src/components/SubTItleBar/styled.ts
+++ b/client/src/components/SubTItleBar/styled.ts
@@ -93,6 +93,10 @@ export const SubTitleButton = styled.a`
   @media (min-width: 768px) and (max-width: 1120px) {
     margin-bottom: -152px;
   }
+  &:hover {
+    background-color: #385c78;
+    color: white;
+  }
 `;
 export const NavButton = styled.a<{ path: string }>`
   color: var(--color-gray200);


### PR DESCRIPTION
<img width="250" alt="스크린샷 2023-07-24 오전 4 58 19" src="https://github.com/codestates-seb/seb44_main_017/assets/100990926/abe371fc-543f-4812-b4fc-47ade98f03d0">

등록, 수정 페이지 반응형 CSS 적용하고 서브타이틀 바 컴포넌트 버튼인지 알기 어려울 것 같아서 위 사진처럼 호버 효과 추가해보았습니다.